### PR TITLE
Postfix Operators Fix and Tests

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -821,7 +821,6 @@ define([
     };
 
     FirstPass.prototype.visitComment = function (ast) {
-        //TODO Use RegEx
         if (ast.value.indexOf("@meta") >= 0) {
             var lineMetaComments = this._metaComments[ast.loc.end.line];
             if (lineMetaComments === undefined) {
@@ -837,6 +836,9 @@ define([
         if (argumentResult.failed()) return defaultResult;
 
         var symbol = argumentResult.value;
+        // If is postfix operator return transient clone of symbol
+        var _symbol = ast.prefix ? symbol : state.addSymbol("@" + symbol.name, symbol.value);
+
         switch (ast.operator) {
         case "++":
             symbol.value++;
@@ -845,7 +847,7 @@ define([
             symbol.value--;
             break;
         }
-        return new Result(true, symbol);
+        return new Result(true, _symbol);
     };
 
     FirstPass.prototype.visitWhileStatement = function (ast, state) {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -837,7 +837,7 @@ define([
 
         var symbol = argumentResult.value;
         // If is postfix operator return transient clone of symbol
-        var _symbol = ast.prefix ? symbol : state.addSymbol("@" + symbol.name, symbol.value);
+        var _symbol = ast.prefix ? symbol : state.transientSymbol("@" + symbol.name, symbol.value);
 
         switch (ast.operator) {
         case "++":

--- a/src/state.js
+++ b/src/state.js
@@ -28,7 +28,6 @@ define([
     };
 
     State.prototype.addSymbol = function (name, value) {
-        if (value === undefined) value = undefined;
         var symbol = new Symbol(name, value);
         if (this._symbols[name] !== undefined) {
             console.warn("Duplicated symbol name \"" + name + "\" in current scope. Old symbol was discarded.");
@@ -42,6 +41,17 @@ define([
             return this.findSymbolInStackFrame(name, this._stackFrame.length - 1);
         }
         else return this._symbols[name];
+    };
+
+    /**
+     * Craft symbol but don't add it to stack.
+     */
+    State.prototype.transientSymbol = function (name, value) {
+        var symbol = new Symbol(name, value);
+        if (this._symbols[name] !== undefined) {
+            console.warn("Symbol already in scope.");
+        }
+        return symbol;
     };
 
     State.prototype.findSymbolInStackFrame = function (name, stackFrameIndex) {

--- a/src/state.js
+++ b/src/state.js
@@ -44,7 +44,7 @@ define([
     };
 
     /**
-     * Craft symbol but don't add it to stack.
+     * Craft symbol but don't add it to the stack.
      */
     State.prototype.transientSymbol = function (name, value) {
         var symbol = new Symbol(name, value);

--- a/test/suites/Tests-11-ECMA.js
+++ b/test/suites/Tests-11-ECMA.js
@@ -43,8 +43,8 @@ define(['pumascript', 'esprima'], function(puma, esprima) {
         equal(result.value,'value',"Passed!");
     });
 
-    test("The new operator",function () {
-        var result = puma.evalPuma("function Car(make, model, year) {this.make = make; this.model = model; this.year = year;} var mycar = new Car('Eagle', 'Talon TSi', 1993);");
+    test("The new Operator",function () {
+        var result = puma.evalPuma("function Car(make, model, year) { this.make = make; this.model = model; this.year = year; } var mycar = new Car('Eagle', 'Talon TSi', 1993);");
         ok(result.success,"Passed!");
     });
 
@@ -62,16 +62,38 @@ define(['pumascript', 'esprima'], function(puma, esprima) {
 
     module("11.3 Postfix Expressions.");
 
-    test("Increment",function () {
-        var result = puma.evalPuma("var x = 0; x++; ");
+    test("Postfix Increment Operator",function () {
+        var result = puma.evalPuma("var x = 0; x++;");
         result.makeValue();
-        equal(result.value,1,"Passed!");
+        equal(result.success, true);
+        equal(result.value, 0);
     });
 
-    test("Decrement",function () {
-        var result = puma.evalPuma("var x = 1; x--; ");
+    test("Postfix Increment Operator 2",function () {
+        var result = puma.evalPuma("var i = 0; var a = []; a[i++] = (function(n,a){ a[n++] = n++; return n; })(i++,a); a[2] = i; a;");
         result.makeValue();
-        equal(result.value,0,"Passed!");
+        equal(result.success, true);
+        equal(result.value.length, 3);
+        equal(result.value[0], 3);
+        equal(result.value[1], 2);
+        equal(result.value[2], 2);
+    });
+
+    test("Postfix Decrement Operator",function () {
+        var result = puma.evalPuma("var x = 0; x--;");
+        result.makeValue();
+        equal(result.success, true);
+        equal(result.value, 0);
+    });
+
+    test("Postfix Decrement Operator 2",function () {
+        var result = puma.evalPuma("var i = 1; var a = []; a[i--] = (function(n,a){ a[n--] = n--; return n; })(i--,a); a[2] = i; a;");
+        result.makeValue();
+        equal(result.success, true);
+        equal(result.value.length, 3);
+        equal(result.value[0], -1);
+        equal(result.value[1], -2);
+        equal(result.value[2], -1);
     });
 
     module("11.4 Unary Operators");

--- a/test/suites/base-tests.js
+++ b/test/suites/base-tests.js
@@ -172,13 +172,13 @@ define(['pumascript', 'esprima'], function(puma, esprima) {
     });
 
     test("While statement 1", function(){
-        var result = puma.evalPuma("var a=0; while(a<10){a++;}");
-        equal(result.value, 10, "Passed!");
+        var result = puma.evalPuma("var a = 0; while(a < 10) { a++; }");
+        equal(result.value, 9, "Passed!");
     });
 
     test("While statement 2", function(){
-        var result = puma.evalPuma("var a=0; var b=true; while(b){if(a>=9){b=false;} a++;}");
-        equal(result.value, 10, "Passed!");
+        var result = puma.evalPuma("var a = 0; var b = true; while(b) { if(a >= 9){b=false;} a++; }");
+        equal(result.value, 9, "Passed!");
     });
 
     test("Object expression", function(){


### PR DESCRIPTION
Conditioned the return values for postfix **_Increment_** and **_Decrement_** operators to follow convened order of execution defined on the standard.

Visitor now returns a clone of the original symbol, which is transient and is not appended to the state's _symbols table. Instead the cloned symbol remains alive throughout runtime until it's either discarded or its materiality is **no longer relevant** (The needed values have been used and is not referenced over the subsequent workflow).

Also fixed the tests for this section and added more comprehensive test cases. Fixes #77 